### PR TITLE
Remove build references from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,6 @@ Install dependencies:
 bun install
 ```
 
-Build the server:
-
-```bash
-bun run build
-```
-
 For development with auto-rebuild:
 
 ```bash
@@ -50,7 +44,7 @@ On Windows: `%APPDATA%/Claude/claude_desktop_config.json`
 {
   "mcpServers": {
     "Calculator": {
-      "command": "/path/to/calculator-mcp/build/index.js"
+      "command": "/path/to/calculator-mcp/src/index.ts"
     }
   }
 }


### PR DESCRIPTION
This PR updates the README.md to remove build references since no build step is required. Changes include:

- Removed build step command from Development section
- Updated installation path to point to `src/index.ts` instead of `build/index.js`

Fixes #1